### PR TITLE
Fix APNS push for the cloud testing environment

### DIFF
--- a/libnymea-app-core/connection/awsclient.cpp
+++ b/libnymea-app-core/connection/awsclient.cpp
@@ -83,7 +83,7 @@ AWSClient::AWSClient(QObject *parent) : QObject(parent),
     config.mqttEndpoint = "a2addxakg5juii-ats.iot.eu-west-1.amazonaws.com";
     config.region = "eu-west-1";
     config.apiEndpoint = "testapi-cloud.guh.io";
-    config.pushNotificationSystem = pushSystem == "APNS" ? pushSystem + "_SANDBOX" : pushSystem;
+    config.pushNotificationSystem = pushSystem;
     m_configs.insert("Testing", config);
 
     // Marantec environment


### PR DESCRIPTION
Whether to use APNS or APNS_SANDBOX doesn't depend on the used
nymea:cloud instance, but rather the used certificate for signing the
app. And we never use an ad-hoc certificate to sign CI builds.