### PR TITLE
Add ios location permission declaration

### DIFF
--- a/packaging/ios/Info.plist.in
+++ b/packaging/ios/Info.plist.in
@@ -34,11 +34,13 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
         <key>NSBluetoothPeripheralUsageDescription</key>
-        <string>Nymea boxes can be connected to WiFi using a Bluetooth setup. Also, this app can connect to nymea boxes using Bluetooth only, without requiring WiFi at all.</string>
+        <string>nymea boxes can be connected to WiFi using a Bluetooth setup. Also, this app can connect to nymea boxes using Bluetooth only, without requiring WiFi at all.</string>
         <key>NSBluetoothAlwaysUsageDescription</key>
-        <string>Nymea boxes can be connected to WiFi using a Bluetooth setup. Also, this app can connect to nymea boxes using Bluetooth only, without requiring WiFi at all.</string>
+        <string>nymea boxes can be connected to WiFi using a Bluetooth setup. Also, this app can connect to nymea boxes using Bluetooth only, without requiring WiFi at all.</string>
         <key>NSLocalNetworkUsageDescription</key>
-        <string>Nymea:app will connect to nymea systems in the local network and allow controlling smart home equipment.</string>
+        <string>nymea:app will connect to nymea systems in the local network and allow controlling smart home equipment.</string>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>nymea:app is not using the device location at this point.</string>
         <key>NSBonjourServices</key>
         <array>
             <string>_jsonrpc._tcp</string>


### PR DESCRIPTION
The PlatformPermissions class allows requesting the location permission, but the app actually never will do so at this point.

Apple still requires this permission string tho...