### PR TITLE
Add missing UnitMilliSeconds and UnitOhm units

### DIFF
--- a/libnymea-app/types/types.cpp
+++ b/libnymea-app/types/types.cpp
@@ -98,6 +98,8 @@ QString Types::toUiUnit(Types::Unit unit) const
     switch (uiUnit) {
     case Types::UnitNone:
         return "";
+    case Types::UnitMilliSeconds:
+        return "ms";
     case Types::UnitSeconds:
         return "s";
     case Types::UnitMinutes:
@@ -198,6 +200,8 @@ QString Types::toUiUnit(Types::Unit unit) const
         return "VAR";
     case Types::UnitAmpereHour:
         return "Ah";
+    case Types::UnitOhm:
+        return "Ω";
     case Types::UnitMicroSiemensPerCentimeter:
         return "µS/cm";
     case Types::UnitDuration:

--- a/libnymea-app/types/types.h
+++ b/libnymea-app/types/types.h
@@ -50,6 +50,7 @@ public:
 
     enum Unit {
         UnitNone,
+        UnitMilliSeconds,
         UnitSeconds,
         UnitMinutes,
         UnitHours,
@@ -100,6 +101,7 @@ public:
         UnitVoltAmpere,
         UnitVoltAmpereReactive,
         UnitAmpereHour,
+        UnitOhm,
         UnitMicroSiemensPerCentimeter,
         UnitDuration,
         UnitNewton,


### PR DESCRIPTION
Sync Unit enum with nymea backend (typeutils.h):
- Add UnitMilliSeconds between UnitNone and UnitSeconds
- Add UnitOhm between UnitAmpereHour and UnitMicroSiemensPerCentimeter
- Add display strings 'ms' and 'Ω' for the new units in toUiUnit()