### PR TITLE
Fix QTranslator leak in main.cpp

### DIFF
--- a/nymea-app/main.cpp
+++ b/nymea-app/main.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
         if (loadedTranslations.contains(qmFile.baseName())) {
             continue;
         }
-        QTranslator *translator = new QTranslator();
+        QTranslator *translator = new QTranslator(&application);
         bool loadResult = translator->load(qmFile.baseName() + "." + QLocale().name(), ":/translations");
         if (loadResult) {
             application.installTranslator(translator);


### PR DESCRIPTION
Successfully installed translators were heap-allocated with no parent, so they were never deleted (QApplication::installTranslator() does not take ownership). Parent them to the QApplication instance so they are cleaned up automatically when the application exits.