### PR TITLE
Fix typo in implicitWidth in StateDelegate.qml

### DIFF
--- a/nymea-app/ui/delegates/StateDelegate.qml
+++ b/nymea-app/ui/delegates/StateDelegate.qml
@@ -138,7 +138,7 @@ ItemDelegate {
             Switch {
                 id: theSwitch
                 anchors { top: parent.top; right: parent.right; bottom: parent.bottom }
-                width: Math.min(parent.width, implicitiWidth)
+                width: Math.min(parent.width, implicitWidth)
                 checked: root.param.value === true
                 Component.onCompleted: {
                     if (root.param.value === undefined) {


### PR DESCRIPTION
There was a typo (implicitiWidth) in the calculation of the Switch's width in boolComponent in StateDelegate.qml.